### PR TITLE
Fix upgrade cost mutation

### DIFF
--- a/lib/__tests__/game-logic.test.ts
+++ b/lib/__tests__/game-logic.test.ts
@@ -1,5 +1,5 @@
-import { generateUniqueId, initializeGameState } from '../game-logic'
-import { BusinessType, ResourceType } from '../game-types'
+import { generateUniqueId, initializeGameState, getUpgradeCost } from '../game-logic'
+import { BusinessType, ResourceType, type Business } from '../game-types'
 
 describe('generateUniqueId', () => {
   it('generates unique IDs with the given prefix', () => {
@@ -62,5 +62,31 @@ describe('initializeGameState', () => {
     expect(state.achievements.relocator).toBe(false)
     expect(state.achievements.maxedOut).toBe(false)
     expect(state.achievements.fastTycoon).toBe(false)
+  })
+})
+
+describe('getUpgradeCost', () => {
+  it('does not mutate the business object', () => {
+    const business = {
+      id: 'b1',
+      type: BusinessType.RESOURCE_GATHERING,
+      position: { x: 0, y: 0 },
+      incomingStorage: { current: 0, capacity: 1 },
+      outgoingStorage: { current: 0, capacity: 1 },
+      processingTime: 1,
+      productionProgress: 0,
+      workers: [],
+      shippingTypes: [],
+      level: 1,
+      inputResource: ResourceType.WOOD,
+      outputResource: ResourceType.WOOD,
+      recentProfit: 0,
+      profitDisplayTime: 0,
+      totalInvested: 0,
+    } as Business
+
+    const cost = getUpgradeCost(business, 'incomingCapacity')
+    expect(cost).toBe(50)
+    expect(business.upgrades).toBeUndefined()
   })
 })

--- a/lib/game-logic.ts
+++ b/lib/game-logic.ts
@@ -52,19 +52,19 @@ export function initializeGameState(): GameState {
 
 export function getUpgradeCost(business: Business, upgradeType?: "incomingCapacity" | "processingTime" | "outgoingCapacity"): number {
   const base = 50
-  // Track upgrades per type on the business object
-  if (!business.upgrades) {
-    business.upgrades = {
-      incomingCapacity: 0,
-      processingTime: 0,
-      outgoingCapacity: 0
-    }
+  // Read upgrades without mutating the business object
+  const upgrades = business.upgrades ?? {
+    incomingCapacity: 0,
+    processingTime: 0,
+    outgoingCapacity: 0,
   }
+
   // If no upgradeType is provided, fallback to old logic
   if (!upgradeType) {
     return Math.floor(base * Math.pow(2, business.level - 1))
   }
+
   // Each upgrade type is independent: first upgrade is 50, then 1.7x each time
-  const n = business.upgrades[upgradeType] || 0;
-  return Math.floor(base * Math.pow(1.7, n));
+  const n = upgrades[upgradeType] || 0
+  return Math.floor(base * Math.pow(1.7, n))
 }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
## Summary
- prevent `getUpgradeCost` from mutating the business
- add regression test for immutability
- include `@testing-library/dom` for tests

## Testing
- `npx jest --runInBand 2>&1 | tail -n 15`

------
https://chatgpt.com/codex/tasks/task_e_683feb63afc8832b8207bae3fec94ca1